### PR TITLE
fixes / improvements to use the IMU in a marine environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .pio/**
 .pio/libdeps/**
-.vscode/**
 .pioenvs/**
 .piolibdeps/**
 *.map

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    // See http://go.microsoft.com/fwlink/?LinkId=827846
+    // for the documentation about the extensions.json format
+    "recommendations": [
+        "platformio.platformio-ide"
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+// AUTOMATICALLY GENERATED FILE. PLEASE DO NOT MODIFY IT MANUALLY
+
+// PIO Unified Debugger
+//
+// Documentation: https://docs.platformio.org/page/plus/debugging.html
+// Configuration: https://docs.platformio.org/page/projectconf/section_env_debug.html
+
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "platformio-debug",
+            "request": "launch",
+            "name": "PIO Debug",
+            "executable": "/home/doudou/dev/tidewise/wetpaint/firmwares/imu_aceinna_openimu/.pio/build/OpenIMU300ZI/firmware.elf",
+            "toolchainBinDir": "/home/doudou/.platformio/packages/toolchain-gccarmnoneeabi/bin",
+            "svdPath": "/home/doudou/.platformio/platforms/aceinna_imu/misc/svd/STM32F40x.svd",
+            "preLaunchTask": {
+                "type": "PlatformIO",
+                "task": "Pre-Debug"
+            },
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "type": "platformio-debug",
+            "request": "launch",
+            "name": "PIO Debug (skip Pre-Debug)",
+            "executable": "/home/doudou/dev/tidewise/wetpaint/firmwares/imu_aceinna_openimu/.pio/build/OpenIMU300ZI/firmware.elf",
+            "toolchainBinDir": "/home/doudou/.platformio/packages/toolchain-gccarmnoneeabi/bin",
+            "svdPath": "/home/doudou/.platformio/platforms/aceinna_imu/misc/svd/STM32F40x.svd",
+            "internalConsoleOptions": "openOnSessionStart"
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.trimAutoWhitespace": false
+}

--- a/lib/Core/Algorithm/include/EKF_Algorithm.h
+++ b/lib/Core/Algorithm/include/EKF_Algorithm.h
@@ -159,6 +159,7 @@ void EKF_GetAttitude_EA_RAD(real *EulerAngles);
 void EKF_GetAttitude_Q(real *Quaternions);
 void EKF_GetCorrectedAngRates(real *CorrAngRates_B);
 void EKF_GetCorrectedAccels(real *CorrAccels_B);
+void EKF_GetCorrectedMags(real *CorrMags_B);
 void EKF_GetEstimatedAngRateBias(real *AngRateBias_B);
 void EKF_GetEstimatedAccelBias(real *AccelBias_B);
 void EKF_GetEstimatedPosition(real *Position_N);

--- a/lib/Core/Algorithm/include/EKF_Algorithm.h
+++ b/lib/Core/Algorithm/include/EKF_Algorithm.h
@@ -153,6 +153,9 @@ uint8_t InitINSFilter(void);
 void EKF_Algorithm(void);
 void enableFreeIntegration(BOOL enable);
 
+void EKF_GetMeasuredEulerAngles(real* angle);
+BOOL EKF_GetMagneticDeclination(real* decl_rad);
+
 // Getters for data extraction from the EKF output data structure
 void EKF_GetAttitude_EA(real *EulerAngles);
 void EKF_GetAttitude_EA_RAD(real *EulerAngles);

--- a/lib/Core/Algorithm/src/EKF_Algorithm.c
+++ b/lib/Core/Algorithm/src/EKF_Algorithm.c
@@ -26,6 +26,7 @@
 #include "UpdateFunctions.h"
 #include "TimingVars.h"
 
+#include "WorldMagneticModel.h"
 
 #ifndef INS_OFFLINE
 #ifdef DISPLAY_DIAGNOSTIC_MSG
@@ -468,6 +469,23 @@ void EKF_GetEstimatedLLA(double *LLA)
     LLA[Z_AXIS] = (double)gEKFOutput.llaDeg[Z_AXIS];
 }
 
+void EKF_GetMeasuredEulerAngles(real* angles)
+{
+    angles[YAW] = gKalmanFilter.measuredEulerAngles[YAW];
+    angles[PITCH] = gKalmanFilter.measuredEulerAngles[PITCH];
+    angles[ROLL] = gKalmanFilter.measuredEulerAngles[ROLL];
+}
+
+BOOL EKF_GetMagneticDeclination(real* decl_rad)
+{
+    if (gWorldMagModel.validSoln) {
+        *decl_rad = gWorldMagModel.decl_rad;
+        return TRUE;
+    }
+    else {
+        return FALSE;
+    }
+}
 
 /* Extract the Operational Mode of the Algorithm:
  *   0: Stabilize

--- a/lib/Core/Algorithm/src/EKF_Algorithm.c
+++ b/lib/Core/Algorithm/src/EKF_Algorithm.c
@@ -405,6 +405,15 @@ void EKF_GetCorrectedAccels(real *CorrAccels_B)
     CorrAccels_B[Z_AXIS] = (real)gEKFOutput.corrAccel_B[Z_AXIS];
 }
 
+/* Extract the magnetometers corrected for hard and soft iron effects
+ */
+void EKF_GetCorrectedMags(real *CorrMags_B)
+{
+    CorrMags_B[X_AXIS] = (real)gEKFInput.magField_B[X_AXIS];
+    CorrMags_B[Y_AXIS] = (real)gEKFInput.magField_B[Y_AXIS];
+    CorrMags_B[Z_AXIS] = (real)gEKFInput.magField_B[Z_AXIS];
+
+}
 
 /* Extract the acceleration of the body (corrected for estimated
  * accelerometer-bias) measured in the body-frame (B).

--- a/lib/Core/Algorithm/src/PredictFunctions.c
+++ b/lib/Core/Algorithm/src/PredictFunctions.c
@@ -157,7 +157,7 @@ void EKF_PredictionStage(real *filteredAccel)
     if ( magUsedInAlgorithm() )
     {
         // Transform the magnetic field vector from the body-frame to the plane normal to the gravity vector
-        if ( gAlgorithm.state == LOW_GAIN_AHRS )
+        if ( gAlgorithm.state >= LOW_GAIN_AHRS )
         {
             // Using predicted pitch and roll to project the mag measurement
             gKalmanFilter.measuredEulerAngles[YAW] =
@@ -181,8 +181,8 @@ void EKF_PredictionStage(real *filteredAccel)
     }
 
 
-    // Adjust for declination if the GPS signal is good
-    if( gAlgorithm.applyDeclFlag ) 
+    // Adjust for declination if we have declination data
+    if( gWorldMagModel.validSoln )
     {
         gKalmanFilter.measuredEulerAngles[YAW] = gKalmanFilter.measuredEulerAngles[YAW] +
                                                  gWorldMagModel.decl_rad;

--- a/lib/Core/Algorithm/src/PredictFunctions.c
+++ b/lib/Core/Algorithm/src/PredictFunctions.c
@@ -775,7 +775,7 @@ static void _UpdateProcessCovariance(void)
      * A scale factor 100 is added here. This is mainly for faster convergence
      * of the heading angle in the INS solution.
      */
-    if (gAlgorithm.state == INS_SOLUTION)
+    if (gAlgorithm.state == INS_SOLUTION && gAlgorithm.velocityAlwaysAlongBodyX)
     {
         tmpQMultiplier = 1.0f * multiplier_Q_Sq;
     }

--- a/lib/Core/Algorithm/src/UpdateFunctions.c
+++ b/lib/Core/Algorithm/src/UpdateFunctions.c
@@ -185,7 +185,7 @@ void EKF_UpdateStage(void)
             {
                 // GPS heading valid?
                 gAlgoStatus.bit.gpsHeadingValid = (gEKFInput.rawGroundSpeed >= LIMIT_MIN_GPS_VELOCITY_HEADING);
-                useGpsHeading = gAlgoStatus.bit.gpsHeadingValid;
+                useGpsHeading = gAlgoStatus.bit.gpsHeadingValid && gAlgorithm.velocityAlwaysAlongBodyX;
 
                 /* If GNSS outage is longer than a threshold (maxReliableDRTime), DR results get unreliable
                  * So, when GNSS comes back, the EKF is reinitialized. Otherwise, the DR results are still
@@ -322,7 +322,7 @@ void ComputeSystemInnovation_Att(void)
         }
         
     }
-    else if ( magUsedInAlgorithm() && gAlgorithm.state <= LOW_GAIN_AHRS )
+    else if ( magUsedInAlgorithm() && (!gAlgorithm.velocityAlwaysAlongBodyX || gAlgorithm.state <= LOW_GAIN_AHRS) )
     {
         gKalmanFilter.nu[STATE_YAW]   = gKalmanFilter.measuredEulerAngles[YAW] -
                                         gKalmanFilter.eulerAngles[YAW];
@@ -628,7 +628,7 @@ void _GenerateObservationCovariance_AHRS(void)
             gKalmanFilter.R[STATE_YAW] *= 10.0;
         }
     }
-    else if ( magUsedInAlgorithm() && gAlgorithm.state <= LOW_GAIN_AHRS )
+    else if ( magUsedInAlgorithm() && (!gAlgorithm.velocityAlwaysAlongBodyX || gAlgorithm.state <= LOW_GAIN_AHRS) )
     {
         // todo: need to further distinguish between if mag is used
         // MAGNETOMETERS

--- a/lib/Core/Algorithm/src/UpdateFunctions.c
+++ b/lib/Core/Algorithm/src/UpdateFunctions.c
@@ -332,7 +332,7 @@ void ComputeSystemInnovation_Att(void)
         gKalmanFilter.nu[STATE_YAW] = (real)0.0;
     }
     gKalmanFilter.nu[STATE_YAW] = _UnwrapAttitudeError(gKalmanFilter.nu[STATE_YAW]);
-    gKalmanFilter.nu[STATE_YAW] = _LimitValue(gKalmanFilter.nu[STATE_YAW], gAlgorithm.Limit.Innov.attitudeError);
+    gKalmanFilter.nu[STATE_YAW] = _LimitValue(gKalmanFilter.nu[STATE_YAW], SIX_DEGREES_IN_RAD*3);
 
     /* When the filtered yaw-rate is above certain thresholds then reduce the
      * attitude-errors used to update roll and pitch.

--- a/lib/Core/Algorithm/src/UpdateFunctions.c
+++ b/lib/Core/Algorithm/src/UpdateFunctions.c
@@ -696,7 +696,7 @@ void _GenerateObservationCovariance_INS(void)
     gKalmanFilter.R[STATE_VX] = temp;// *((real)1.0 + fabs(gAlgorithm.filteredYawRate) * (real)RAD_TO_DEG);
     gKalmanFilter.R[STATE_VX] = gKalmanFilter.R[STATE_VX] * gKalmanFilter.R[STATE_VX];
     gKalmanFilter.R[STATE_VY] = gKalmanFilter.R[STATE_VX];
-    if (gAlgorithm.headingIni == HEADING_UNINITIALIZED)
+    if (!magUsedInAlgorithm() && gAlgorithm.headingIni == HEADING_UNINITIALIZED)
     {
         /* When heading is not initialized, velocity measurement is not able to correct 
          * attitude/rate bias/accel bias, the larger the velocity, the more uncertain it is.
@@ -1226,7 +1226,7 @@ static void Update_GPS(void)
     ComputeSystemInnovation_Att();
 
     // Initialize heading. If getting initial heading at this step, do not update att
-    if (gAlgorithm.headingIni < HEADING_GNSS_HIGH)
+    if (gAlgorithm.velocityAlwaysAlongBodyX && gAlgorithm.headingIni < HEADING_GNSS_HIGH)
     {
         if (InitializeHeadingFromGnss())
         {

--- a/lib/Core/UARTComm/CommonMessages.c
+++ b/lib/Core/UARTComm/CommonMessages.c
@@ -339,9 +339,9 @@ BOOL Fill_e2PacketPayload(uint8_t *payload, uint8_t *payloadLen)
         pld->velocity[i] = fData[i]; 
     }
 
-    GetMagData_G(dData);
+    EKF_GetCorrectedMags(fData);
     for(int i = 0; i < NUM_AXIS; i++){
-        pld->mags[i] = (float)dData[i]; 
+        pld->mags[i] = (float)fData[i];
     }
 
     EKF_GetEstimatedLLA(dData);

--- a/src/appVersion.h
+++ b/src/appVersion.h
@@ -26,7 +26,7 @@ limitations under the License.
 #ifndef _INS_APP_VERSION_H
 #define _INS_APP_VERSION_H
 
-#define  APP_VERSION_STRING  "OpenIMU300ZI INS 1.1.1"
+#define  APP_VERSION_STRING  "OpenIMU300ZI INS 1.1.1 TW1"
 
 
 #endif

--- a/src/user/TidewiseMessages.c
+++ b/src/user/TidewiseMessages.c
@@ -1,0 +1,78 @@
+#include "TidewiseMessages.h"
+#include "GlobalConstants.h"
+#include "boardAPI.h"
+#include "platformAPI.h"
+#include "sensorsAPI.h"
+#include "EKF_Algorithm.h"
+#include "WorldMagneticModel.h"
+
+static uint8_t makeFilterFlags() {
+    uint8_t opMode, linAccelSw, turnSw;
+    EKF_GetOperationalMode(&opMode);
+    EKF_GetOperationalSwitches(&linAccelSw, &turnSw);
+
+    uint8_t flags = opMode;
+    if (linAccelSw) {
+        flags |= 8;
+    }
+    if (turnSw) {
+        flags |= 16;
+    }
+
+    return flags;
+}
+
+BOOL Fill_IMUStatePacketPayload(uint8_t *payload, uint8_t *payloadLen) {
+    imu_state_payload_t *pld = (imu_state_payload_t *)payload;
+    *payloadLen = sizeof(imu_state_payload_t);
+
+    pld->filterFlags = makeFilterFlags();
+    double temp;
+    GetBoardTempData(&temp);
+    pld->temperature_C = (uint8_t)temp;
+    pld->gpsSolution = gEKFInput.gpsFixType;
+    if (gWorldMagModel.validSoln) {
+        pld->magneticDeclination = gWorldMagModel.decl_rad;
+    }
+    else {
+        pld->magneticDeclination = 0;
+    }
+
+    return TRUE;
+}
+
+BOOL Fill_e4PacketPayload(uint8_t *payload, uint8_t *payloadLen) {
+    ekf4_payload_t *pld = (ekf4_payload_t *)payload;
+    *payloadLen  = sizeof(ekf4_payload_t);
+    pld->tstmp   = platformGetIMUCounter();
+
+    real  realData[4];
+    double dData[3];
+
+    *payloadLen  = sizeof(ekf4_payload_t);
+    pld->tstmp   = platformGetIMUCounter();
+
+    EKF_GetEstimatedLLA(dData);
+    for(int i = 0; i < NUM_AXIS; i++){
+        pld->pos[i] = dData[i];
+    }
+
+    EKF_GetAttitude_Q(realData);
+    for (int i = 0; i < 4; ++i) {
+        pld->q[i] = (float)realData[i];
+    }
+
+    EKF_GetEstimatedVelocity(realData);
+    for(int i = 0; i < NUM_AXIS; i++){
+        pld->velocity[i] = (float)realData[i];
+    }
+
+    EKF_GetCorrectedAngRates(realData);
+    for(int i = 0; i < NUM_AXIS; i++){
+        pld->angularVelocities[i] = (float)realData[i];
+    }
+
+    pld->filterFlags = makeFilterFlags();
+    return TRUE;
+}
+

--- a/src/user/TidewiseMessages.c
+++ b/src/user/TidewiseMessages.c
@@ -72,6 +72,23 @@ BOOL Fill_e4PacketPayload(uint8_t *payload, uint8_t *payloadLen) {
         pld->angularVelocities[i] = (float)realData[i];
     }
 
+    EKF_GetCorrectedMags(realData);
+    for(int i = 0; i < NUM_AXIS; i++){
+        pld->magnetometers[i] = (float)realData[i];
+    }
+
+    EKF_GetMeasuredEulerAngles(realData);
+    for(int i = 0; i < NUM_AXIS; i++){
+        pld->measuredEulerAngles[i] = (float)realData[i];
+    }
+
+    if (EKF_GetMagneticDeclination(realData)) {
+        pld->magneticDeclination = (float)realData[0];
+    }
+    else {
+        pld->magneticDeclination = 0;
+    }
+
     pld->filterFlags = makeFilterFlags();
     return TRUE;
 }

--- a/src/user/TidewiseMessages.h
+++ b/src/user/TidewiseMessages.h
@@ -19,9 +19,15 @@ typedef struct {
     float    angularVelocities[3];
     float    velocity[3];
     double   pos[3];
+    float    magnetometers[3];
+    float    measuredEulerAngles[3];
+    float    magneticDeclination;
     uint8_t  filterFlags;
 }ekf4_payload_t;
 #pragma pack()
+
+#define TW_STATE_SIZE 11
+#define TW_E4_SIZE 97
 
 BOOL Fill_IMUStatePacketPayload(uint8_t *payload, uint8_t *payloadLen);
 BOOL Fill_e4PacketPayload(uint8_t *payload, uint8_t *payloadLen);

--- a/src/user/TidewiseMessages.h
+++ b/src/user/TidewiseMessages.h
@@ -15,6 +15,7 @@ typedef struct {
 
 typedef struct {
     uint32_t tstmp;
+    uint8_t  filterFlags;
     float    q[4];
     float    angularVelocities[3];
     float    velocity[3];
@@ -22,7 +23,6 @@ typedef struct {
     float    magnetometers[3];
     float    measuredEulerAngles[3];
     float    magneticDeclination;
-    uint8_t  filterFlags;
 }ekf4_payload_t;
 #pragma pack()
 

--- a/src/user/TidewiseMessages.h
+++ b/src/user/TidewiseMessages.h
@@ -1,0 +1,29 @@
+#ifndef _TIDEWISE_MESSAGES_H
+#define _TIDEWISE_MESSAGES_H
+
+#include <stdint.h>
+#include "GlobalConstants.h"
+
+#pragma pack(1)
+typedef struct {
+    uint32_t tstmp;
+    uint8_t  temperature_C;
+    uint8_t  gpsSolution;
+    float    magneticDeclination;
+    uint8_t  filterFlags;
+}imu_state_payload_t;
+
+typedef struct {
+    uint32_t tstmp;
+    float    q[4];
+    float    angularVelocities[3];
+    float    velocity[3];
+    double   pos[3];
+    uint8_t  filterFlags;
+}ekf4_payload_t;
+#pragma pack()
+
+BOOL Fill_IMUStatePacketPayload(uint8_t *payload, uint8_t *payloadLen);
+BOOL Fill_e4PacketPayload(uint8_t *payload, uint8_t *payloadLen);
+
+#endif

--- a/src/user/UserAlgorithm.c
+++ b/src/user/UserAlgorithm.c
@@ -107,7 +107,7 @@ static void _InitAlgo(uint8_t algoType)
         // Reset 'initAlgo' so this is not executed more than once.  This
         //   prevents the algorithm from being switched during run-time.
         initAlgo = 0;
-        
+
         // Set the configuration variables for a VG-type solution
         //   (useMags = 0 forces the VG solution)
         gAlgorithm.Behavior.bit.freeIntegrate      = 0;
@@ -116,6 +116,10 @@ static void _InitAlgo(uint8_t algoType)
         gAlgorithm.Behavior.bit.useOdo             = 0;
         gAlgorithm.Behavior.bit.restartOnOverRange = 0;
         gAlgorithm.Behavior.bit.dynamicMotion      = 1;
+        gAlgorithm.Behavior.bit.enableStationaryLockYaw = FALSE;
+        gAlgorithm.Behavior.bit.enableImuStaticDetect = FALSE;
+        gAlgorithm.velocityAlwaysAlongBodyX = FALSE;
+        gAlgorithm.staticDetectParam.staticGnssVel = 0;
 
         // Set the system configuration based on system type
         switch( algoType ) {
@@ -132,7 +136,7 @@ static void _InitAlgo(uint8_t algoType)
                 /* Set the configuration variables for INS solution.
                  * (Enable GPS and set algorithm calling frequency to 100Hz)
                  */
-                enableMagInAlgorithm(FALSE);
+                enableMagInAlgorithm(TRUE);
                 enableGpsInAlgorithm(TRUE);
                 enableOdoInAlgorithm(FALSE);
                 gAlgorithm.callingFreq = FREQ_100_HZ;  // redundant; set above

--- a/src/user/UserMessagingUART.c
+++ b/src/user/UserMessagingUART.c
@@ -37,6 +37,7 @@ limitations under the License.
 #include "UserAlgorithm.h"
 #include "UserConfiguration.h"
 #include "CommonMessages.h"
+#include "TidewiseMessages.h"
 
 #include "MagAlign.h"
 
@@ -85,6 +86,7 @@ usr_packet_t userInputPackets[] = {
     {USR_IN_GET_ALL,            "gA"}, 
     {USR_IN_GET_VERSION,        "gV"}, 
     {USR_IN_RESET,              "rS"}, 
+    {USR_IN_GET_IMU_STATE,      "gS"},
 // place new input packet code here, before USR_IN_MAX
     {USR_IN_MAG_ALIGN,          "ma"},   // 0x6D 0x61
     {USR_IN_MAX,                {0xff, 0xff}},   //  "" 
@@ -105,7 +107,8 @@ usr_packet_t userOutputPackets[] = {
     {USR_OUT_SCALED1,           "s1"},
     {USR_OUT_EKF1,              "e1"},
     {USR_OUT_EKF2,              "e2"},
-    {USR_OUT_MAX,               {0xff, 0xff}},   //  "" 
+    {USR_OUT_EKF4,              "e4"},
+    {USR_OUT_MAX,               {0xff, 0xff}},   //  ""
 };
 
 volatile char   *info;
@@ -218,6 +221,10 @@ BOOL setUserPacketType(uint8_t *data, BOOL fApply)
             _outputPacketType = type;
             _userPayloadLen   = USR_OUT_EKF2_PAYLOAD_LEN;
             break;
+        case USR_OUT_EKF4: // packet with EKF algorithm data
+            _outputPacketType = type;
+            _userPayloadLen   = USR_OUT_EKF2_PAYLOAD_LEN;
+            break;
         default:
             result = FALSE;
             break;
@@ -281,6 +288,13 @@ int HandleUserInputPacket(UcbPacketStruct *ptrUcbPacket)
             {
                 uint8_t len;
                 Fill_VersionPacketPayload(ptrUcbPacket->payload, &len);
+                ptrUcbPacket->payloadLength = len;
+            }
+            break;
+		case USR_IN_GET_IMU_STATE:
+            {
+                uint8_t len;
+                Fill_IMUStatePacketPayload(ptrUcbPacket->payload, &len);
                 ptrUcbPacket->payloadLength = len;
             }
             break;
@@ -535,6 +549,15 @@ BOOL HandleUserOutputPacket(uint8_t *payload, uint8_t *payloadLen)
                 // Variables used to hold the EKF values
                 uint8_t len;
                 Fill_e2PacketPayload(payload, &len);
+                *payloadLen = len;
+            }
+            break;
+
+        case USR_OUT_EKF4:
+            {
+                // Variables used to hold the EKF values
+                uint8_t len;
+                Fill_e4PacketPayload(payload, &len);
                 *payloadLen = len;
             }
             break;

--- a/src/user/UserMessagingUART.h
+++ b/src/user/UserMessagingUART.h
@@ -128,7 +128,7 @@ typedef struct {
 #define USR_OUT_SCALED1_PAYLOAD_LEN (52)
 #define USR_OUT_EKF1_PAYLOAD_LEN    (75)
 #define USR_OUT_EKF2_PAYLOAD_LEN    (123)
-#define USR_OUT_EKF4_PAYLOAD_LEN    (69)
+#define USR_OUT_EKF4_PAYLOAD_LEN    (TW_E4_SIZE)
 
 #define USER_OK      0x00
 #define USER_NAK     0x80

--- a/src/user/UserMessagingUART.h
+++ b/src/user/UserMessagingUART.h
@@ -66,6 +66,7 @@ typedef enum {
     USR_IN_GET_PARAM        ,
     USR_IN_GET_ALL          ,
     USR_IN_GET_VERSION      ,
+    USR_IN_GET_IMU_STATE    ,
     USR_IN_RESET            ,
     // add new packet type here, before USR_IN_MAX
     USR_IN_MAG_ALIGN        ,
@@ -83,6 +84,7 @@ typedef enum {
     USR_OUT_SCALED1,
     USR_OUT_EKF1,
     USR_OUT_EKF2,
+    USR_OUT_EKF4,
     USR_OUT_MAX
 } UserOutPacketType;
 
@@ -126,6 +128,7 @@ typedef struct {
 #define USR_OUT_SCALED1_PAYLOAD_LEN (52)
 #define USR_OUT_EKF1_PAYLOAD_LEN    (75)
 #define USR_OUT_EKF2_PAYLOAD_LEN    (123)
+#define USR_OUT_EKF4_PAYLOAD_LEN    (69)
 
 #define USER_OK      0x00
 #define USER_NAK     0x80


### PR DESCRIPTION
The main goal is to use magnetometers and GPS at the same time, as well as turn velocityAlongBodyXAxis to FALSE. The firmware had a lot of codepaths were the mags would be ignored in INS mode, and/or where the assumption that velocity is along X would still be used even though the flag is false.

Note that this version cannot be used as-is on Tupan. The current firmware assumes that the X/Y axes of the IMU are mounted horizontally, but the motion box has Y pointing up. Other changes (in the tupan branch) are handling this particular issue.