### PR TITLE
tupan: application of hard iron bias on the Z axis

### DIFF
--- a/lib/Core/Algorithm/src/EKF_Algorithm.c
+++ b/lib/Core/Algorithm/src/EKF_Algorithm.c
@@ -531,7 +531,7 @@ void EKF_SetInputStruct(double *accels, double *rates, double *mags,
     gEKFInput.magField_B[Z_AXIS] = (real)mags[Z_AXIS];
     real tmp[2];
     tmp[X_AXIS] = gEKFInput.magField_B[X_AXIS] - gMagAlign.hardIronBias[X_AXIS];
-    tmp[Z_AXIS] = gEKFInput.magField_B[Z_AXIS] - gMagAlign.hardIronBias[Z_AXIS];
+    tmp[Z_AXIS] = gEKFInput.magField_B[Z_AXIS] - gMagAlign.hardIronBias[Y_AXIS];
     gEKFInput.magField_B[X_AXIS] = gMagAlign.SF[0] * tmp[X_AXIS] + gMagAlign.SF[1] * tmp[Z_AXIS];
     gEKFInput.magField_B[Z_AXIS] = gMagAlign.SF[2] * tmp[X_AXIS] + gMagAlign.SF[3] * tmp[Z_AXIS];
 


### PR DESCRIPTION
The hard iron bias is a 2-element array and Z_AXIS is 2. This bug is coming from the changes we did to adapt the firmware for a mounting where Z is sideways and Y upwards.