### PR TITLE
Add rtkheading2magheading configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/openimu-core"]
 	path = lib/openimu-core
 	url = https://github.com/tidewise/openimu-core
+[submodule "lib/openIMU300-lib"]
+	path = lib/openIMU300-lib
+	url = https://github.com/Aceinna/openIMU300-lib

--- a/lib/Core/Algorithm/algorithmAPI.h
+++ b/lib/Core/Algorithm/algorithmAPI.h
@@ -106,4 +106,11 @@ void setLeverArm( real leverArmBx, real leverArmBy, real leverArmBz );
  *****************************************************************************/
 void setPointOfInterest( real poiBx, real poiBy, real poiBz );
 
+/******************************************************************************
+ * @name setRTKHeading2MAGHeading
+ * @brief Set the offset between rtk heading and magnetometer
+ * @param [in] rtkHeading2magHeading: the offset in degrees
+ ****************************************************************************/
+void setRTKHeading2MAGHeading(real rtkHeading2magHeading);
+
 #endif

--- a/lib/Core/Algorithm/include/algorithm.h
+++ b/lib/Core/Algorithm/include/algorithm.h
@@ -208,6 +208,8 @@ typedef struct {
     real leverArmB[3];					// Antenna position w.r.t IMU in vehicle body frame
     real pointOfInterestB[3];			// Point of interest position w.r.t IMU in vehicle body frame
 
+    real rtkHeading2magHeading;
+
     BOOL velocityAlwaysAlongBodyX;      // enable zero velocity update
 
     IMU_SPEC imuSpec;                   // IMU specifications

--- a/lib/Core/Algorithm/src/algorithm.c
+++ b/lib/Core/Algorithm/src/algorithm.c
@@ -125,6 +125,8 @@ void InitializeAlgorithmStruct(uint8_t callingFreq)
     gAlgorithm.pointOfInterestB[Y_AXIS] = 0.0;
     gAlgorithm.pointOfInterestB[Z_AXIS] = 0.0;
 
+    gAlgorithm.rtkHeading2magHeading = NAN;
+
     // For most vehicles, the velocity is always along the body x axis
     gAlgorithm.velocityAlwaysAlongBodyX = TRUE;
 
@@ -211,6 +213,11 @@ void setPointOfInterest( real poiBx, real poiBy, real poiBz )
     gAlgorithm.pointOfInterestB[0] = poiBx;
     gAlgorithm.pointOfInterestB[1] = poiBy;
     gAlgorithm.pointOfInterestB[2] = poiBz;
+}
+
+void setRTKHeading2MAGHeading(real rtkHeading2magHeading)
+{
+    gAlgorithm.rtkHeading2magHeading = rtkHeading2magHeading;
 }
 
 void UpdateImuSpec(real rwOdr, real arw, real biw, real maxBiasW,

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,8 +20,7 @@ description =
 platform = aceinna_imu
 lib_archive = false
 board = OpenIMU300
-;lib_deps= ../../OpenIMU300-lib
-lib_deps = OpenIMU300-base-library@1.0.9
+lib_extra_dirs = "./lib/openIMU300-lib"
 build_flags =
 	-D CLI
 	-D GPS

--- a/src/user/UserConfiguration.c
+++ b/src/user/UserConfiguration.c
@@ -61,6 +61,7 @@ const UserConfigurationStruct gDefaultUserConfig = {
     .pointOfInterestBx   = 0.0,
     .pointOfInterestBy   = 0.0,
     .pointOfInterestBz   = 0.0,
+    .rtkHeading2magHeading = NAN,
 };
 
 UserConfigurationStruct gUserConfiguration;
@@ -242,6 +243,12 @@ BOOL  UpdateUserParameter(uint32_t number, uint64_t data, BOOL fApply)
                          (real)gUserConfiguration.leverArmBz );
             result = TRUE;
             break;   
+        case USER_RTK_HEADING2MAG_HEADING:
+            tmp = (double*) &data;
+            gUserConfiguration.rtkHeading2magHeading = *tmp;
+            setRTKHeading2MAGHeading((real) gUserConfiguration.rtkHeading2magHeading);
+            result = TRUE;
+            break;
         // case USER_XXX_OFFSET:  add function calls here if parameter XXXX
         //                        required be updated on the fly and/or validated
         //             break;

--- a/src/user/UserConfiguration.h
+++ b/src/user/UserConfiguration.h
@@ -100,6 +100,7 @@ typedef struct {
     double pointOfInterestBx;
     double pointOfInterestBy;
     double pointOfInterestBz;
+    double rtkHeading2magHeading; // [deg]
 } UserConfigurationStruct;
 
 typedef enum {
@@ -128,6 +129,7 @@ typedef enum {
     USER_POINT_OF_INTEREST_BX         ,
     USER_POINT_OF_INTEREST_BY         ,
     USER_POINT_OF_INTEREST_BZ         ,
+    USER_RTK_HEADING2MAG_HEADING      ,
     USER_MAX_PARAM
 } UserConfigParamNumber;
 


### PR DESCRIPTION
[sc-59323]

Create rtkHeading2magHeading user configuration. When using gnss heading as source for orientation (instead of mags) this value will be added to the gnss heading value before feeding it to the filter.

