### PR TITLE
feat: use rtk heading

### DIFF
--- a/lib/Core/Algorithm/algorithmAPI.h
+++ b/lib/Core/Algorithm/algorithmAPI.h
@@ -109,7 +109,7 @@ void setPointOfInterest( real poiBx, real poiBy, real poiBz );
 /******************************************************************************
  * @name setRTKHeading2MAGHeading
  * @brief Set the offset between rtk heading and magnetometer
- * @param [in] rtkHeading2magHeading: the offset in degrees
+ * @param [in] rtkHeading2magHeading: the offset in radians
  ****************************************************************************/
 void setRTKHeading2MAGHeading(real rtkHeading2magHeading);
 

--- a/lib/Core/Algorithm/include/EKF_Algorithm.h
+++ b/lib/Core/Algorithm/include/EKF_Algorithm.h
@@ -109,6 +109,7 @@ typedef struct {
     uint8_t numSatellites;          /* Num of satellites in this GNSS measurement.
                                      * This is valid only when there is gps udpate.
                                      */
+    rtkHeadingStruct_t rtkHeading;
     BOOL gpsUpdate;                 // Indicate if GNSS measurement is updated.
 
     // odometer

--- a/lib/Core/Algorithm/include/algorithm.h
+++ b/lib/Core/Algorithm/include/algorithm.h
@@ -52,6 +52,7 @@ limitations under the License.
 #define HEADING_MAG             1
 #define HEADING_GNSS_LOW        2
 #define HEADING_GNSS_HIGH       3
+#define HEADING_RTK             4
 
 typedef struct {
 	uint32_t Stabilize_System;      // SAMPLING_RATE * 0.36
@@ -208,7 +209,7 @@ typedef struct {
     real leverArmB[3];					// Antenna position w.r.t IMU in vehicle body frame
     real pointOfInterestB[3];			// Point of interest position w.r.t IMU in vehicle body frame
 
-    real rtkHeading2magHeading;
+    real rtkHeading2magHeading; // radians
 
     BOOL velocityAlwaysAlongBodyX;      // enable zero velocity update
 

--- a/lib/Core/Algorithm/src/EKF_Algorithm.c
+++ b/lib/Core/Algorithm/src/EKF_Algorithm.c
@@ -649,6 +649,13 @@ void EKF_SetInputStruct(double *accels, double *rates, double *mags,
                           &gKalmanFilter.Rn2e[0][0],
                           &gKalmanFilter.rGPS_N[0]);
         }
+
+        gEKFInput.rtkHeading.valid = gps->rtkHeadingData.valid;
+        if (gEKFInput.rtkHeading.valid) {
+            gEKFInput.rtkHeading.heading = gps->rtkHeadingData.heading
+                + gAlgorithm.rtkHeading2magHeading;
+            gEKFInput.rtkHeading.headingAccuracy = gps->rtkHeadingData.headingAccuracy;
+        }
     }
 
     // odometer

--- a/lib/Core/Algorithm/src/UpdateFunctions.c
+++ b/lib/Core/Algorithm/src/UpdateFunctions.c
@@ -79,6 +79,8 @@ static void ApplyGpsDealyCorrForStateCov();
 ******************************************************************************/
 static int InitializeHeadingFromGnss();
 
+static int InitializeHeadingFromRTK();
+
 /******************************************************************************
  * @brief When heading is ready for initialization, the heading angle (yaw, and 
  * indeed quaternion in the Kalman filter) is initialized to match the value of
@@ -91,7 +93,9 @@ static int InitializeHeadingFromGnss();
  * TRACE:
  * @retval None.
 ******************************************************************************/
-static void InitializeEkfHeading();
+static void InitializeEkfHeading(float headingMeasurement, float headingMeasurementCov);
+
+static void computeHeadingFromGps(float* heading, float* covariance);
 
 // Update rates
 #define  TEN_HERTZ_UPDATE          10
@@ -105,6 +109,9 @@ static BOOL useGpsHeading = 0;  /* When GPS velocity is above a certain threshol
                                  * is used, otherwise, this is set to 0 and magnetic
                                  * heading is used.
                                  */
+
+static BOOL useRTKHeading = 0;
+
 static int runInsUpdate = 0;    /* To enable the update to be broken up into
                                  * two sequential calculations in two sucessive
                                  * 100 Hz periods.
@@ -187,6 +194,7 @@ void EKF_UpdateStage(void)
                 gAlgoStatus.bit.gpsHeadingValid = (gEKFInput.rawGroundSpeed >= LIMIT_MIN_GPS_VELOCITY_HEADING);
                 useGpsHeading = gAlgoStatus.bit.gpsHeadingValid && gAlgorithm.velocityAlwaysAlongBodyX;
 
+                useRTKHeading = !isnan(gAlgorithm.rtkHeading2magHeading) && gEKFInput.rtkHeading.valid;
                 /* If GNSS outage is longer than a threshold (maxReliableDRTime), DR results get unreliable
                  * So, when GNSS comes back, the EKF is reinitialized. Otherwise, the DR results are still
                  * good, just correct the filter states with input GNSS measurement.
@@ -301,7 +309,17 @@ void ComputeSystemInnovation_Att(void)
 
     // ----- Yaw -----
     // CHANGED TO SWITCH BETWEEN GPS AND MAG UPDATES
-    if ( useGpsHeading )
+    if (useRTKHeading) {
+        if (gAlgorithm.headingIni >= HEADING_RTK) {
+            gKalmanFilter.nu[STATE_YAW] = gEKFInput.rtkHeading.heading -
+                gKalmanFilter.eulerAngles[YAW];
+        }
+        else
+        {
+            gKalmanFilter.nu[STATE_YAW] = (real) 0.0;
+        }
+    }
+    else if ( useGpsHeading )
     {
         if (gAlgorithm.headingIni >= HEADING_GNSS_LOW)   // heading already initialized with GNSS heading
         {
@@ -619,7 +637,11 @@ void _GenerateObservationCovariance_AHRS(void)
      * ----- Yaw -----
      * CHANGED TO SWITCH BETWEEN GPS AND MAG UPDATES
      */
-    if ( useGpsHeading )
+    if (useRTKHeading) {
+        gKalmanFilter.R[STATE_YAW] = gEKFInput.rtkHeading.headingAccuracy *
+            gEKFInput.rtkHeading.headingAccuracy;
+    }
+    else if ( useGpsHeading )
     {
         float temp = (float)atan( 0.05 / gEKFInput.rawGroundSpeed );
         gKalmanFilter.R[STATE_YAW] = temp * temp;
@@ -1230,13 +1252,29 @@ static void Update_GPS(void)
     {
         if (InitializeHeadingFromGnss())
         {
+            float heading, cov;
+            computeHeadingFromGps(&heading, &cov);
             // Heading is initialized. Related elements in the EKF also need intializing.
-            InitializeEkfHeading();
+            InitializeEkfHeading(heading, cov);
 
             /* This heading measurement is used to initialize heading, and should not be
              * used to update heading.
              */
             useGpsHeading = FALSE;
+        }
+    }
+
+    if(!isnan(gAlgorithm.rtkHeading2magHeading) && gAlgorithm.headingIni < HEADING_RTK){
+        if(InitializeHeadingFromRTK()){
+            // Heading is initialized. Related elements in the EKF also need intializing.
+            InitializeEkfHeading(gEKFInput.rtkHeading.heading +
+                                    gAlgorithm.rtkHeading2magHeading,
+                                 gEKFInput.rtkHeading.headingAccuracy);
+
+            /* This heading measurement is used to initialize heading, and should not be
+             * used to update heading.
+             */
+            useRTKHeading = FALSE;
         }
     }
 }
@@ -1813,14 +1851,45 @@ static int InitializeHeadingFromGnss()
     return thisHeadingUsedForIni;
 }
 
-static void InitializeEkfHeading()
+static int InitializeHeadingFromRTK()
+{
+    /* enable declination correction, but the corrected magnetic yaw will not
+     * be used if GPS is available.
+     */
+    gAlgorithm.applyDeclFlag = TRUE;
+
+    if (useRTKHeading) {
+        gAlgorithm.headingIni = HEADING_RTK;
+        return true;
+    }
+
+    return false;
+}
+
+static void computeHeadingFromGps(float* heading, float* covariance)
+{
+    *heading = gEKFInput.trueCourse * D2R;
+
+    // the initial covariance of the quaternion is estimated from ground speed.
+    float temp = (float)atan(0.05 / gEKFInput.rawGroundSpeed);
+    temp *= temp;   // heading var
+    if (gAlgoStatus.bit.turnSwitch)
+    {
+        temp *= 10.0;   // when rotating, heading var increases
+    }
+    temp /= 4.0;        // sin(heading/2) or cos(heading/2)
+
+    *covariance = temp;
+}
+
+static void InitializeEkfHeading(float headingMeasurement, float headingMeasurementCov)
 {
     /* Compare the reliable heading with Kalamn filter heading. If the difference exceeds
      * a certain threshold, this means the immediate heading initialization is unreliable,
      * and the Kalman filter needs reinitialized with the reliable one.
      */
-    float angleDiff = (float)fabs(AngleErrDeg(gEKFInput.trueCourse - 
-                                              gKalmanFilter.eulerAngles[2] * (float)R2D));
+    float angleDiff = (float)fabs(AngleErrDeg((float)R2D * (headingMeasurement -
+                                              gKalmanFilter.eulerAngles[2])));
     if (angleDiff <= 2.0)
     {
         return;
@@ -1837,7 +1906,7 @@ static void InitializeEkfHeading()
 #endif
 
     // initialize yaw angle with GPS heading
-    gKalmanFilter.eulerAngles[YAW] = (gEKFInput.trueCourse * D2R);
+    gKalmanFilter.eulerAngles[YAW] = headingMeasurement;
     if (gKalmanFilter.eulerAngles[YAW] > PI)
     {
         gKalmanFilter.eulerAngles[YAW] -= (real)TWO_PI;
@@ -1906,19 +1975,11 @@ static void InitializeEkfHeading()
         }
     }
 
-    // the initial covariance of the quaternion is estimated from ground speed.
-    float temp = (float)atan(0.05 / gEKFInput.rawGroundSpeed);
-    temp *= temp;   // heading var
-    if (gAlgoStatus.bit.turnSwitch)
-    {
-        temp *= 10.0;   // when rotating, heading var increases
-    }
-    temp /= 4.0;        // sin(heading/2) or cos(heading/2)
     float sinYawSqr = (real)sin(gKalmanFilter.eulerAngles[YAW] / 2.0f);
     sinYawSqr *= sinYawSqr;
     //  Assume roll and pitch are close to 0deg
-    gKalmanFilter.P[STATE_Q0][STATE_Q0] = temp * sinYawSqr;
-    gKalmanFilter.P[STATE_Q3][STATE_Q3] = temp * (1.0f - sinYawSqr);
+    gKalmanFilter.P[STATE_Q0][STATE_Q0] = headingMeasurementCov * sinYawSqr;
+    gKalmanFilter.P[STATE_Q3][STATE_Q3] = headingMeasurementCov * (1.0f - sinYawSqr);
 
     gKalmanFilter.P[STATE_VX][STATE_VX] = gKalmanFilter.R[STATE_VX];
     gKalmanFilter.P[STATE_VY][STATE_VY] = gKalmanFilter.R[STATE_VY];

--- a/lib/Core/GPS/gpsAPI.h
+++ b/lib/Core/GPS/gpsAPI.h
@@ -54,6 +54,12 @@ void TaskGps(void const *argument);
 #define MANUAL      7   // Manual Input Mode (will be considered as INVALID)
 #define SIMULATION  8   // Simulation Mode (will be considered as INVALID)
 
+typedef struct {
+    uint8_t valid;
+    float   heading;
+    float   headingAccuracy;
+} rtkHeadingStruct_t;
+
 typedef struct  {
     uint8_t     gpsFixType;     // 1 if data is valid
     uint8_t     gpsUpdate;      // 1 if contains new data
@@ -79,6 +85,9 @@ typedef struct  {
     float       GPSHorizAcc, GPSVertAcc;
     float       HDOP;
     float       geoidAboveEllipsoid;    // [m] Height of geoid (mean sea level) above WGS84 ellipsoid
+
+    rtkHeadingStruct_t rtkHeadingData;
+
 } gpsDataStruct_t;
 
 extern gpsDataStruct_t gGPS, gCanGps;

--- a/lib/Core/GPS/src/driverGPS.c
+++ b/lib/Core/GPS/src/driverGPS.c
@@ -309,6 +309,10 @@ void GetGPSData(gpsDataStruct_t *data)
         data->GPSHorizAcc       = gGpsDataPtr->GPSHorizAcc;
         data->GPSVertAcc        = gGpsDataPtr->GPSVertAcc;
         data->geoidAboveEllipsoid = gGpsDataPtr->geoidAboveEllipsoid;
+
+        data->rtkHeadingData.valid = gGpsData.movingBaseRTKValid;
+        data->rtkHeadingData.heading = gGpsData.relPosHeading * D2R;
+        data->rtkHeadingData.headingAccuracy = gGpsData.accRelPosHeading * D2R;
     }
 }
 

--- a/src/user/UserConfiguration.c
+++ b/src/user/UserConfiguration.c
@@ -22,6 +22,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 *******************************************************************************/
+#include <math.h>
 
 #include "string.h"
 

--- a/src/user/UserConfiguration.c
+++ b/src/user/UserConfiguration.c
@@ -246,7 +246,7 @@ BOOL  UpdateUserParameter(uint32_t number, uint64_t data, BOOL fApply)
         case USER_RTK_HEADING2MAG_HEADING:
             tmp = (double*) &data;
             gUserConfiguration.rtkHeading2magHeading = *tmp;
-            setRTKHeading2MAGHeading((real) gUserConfiguration.rtkHeading2magHeading);
+            setRTKHeading2MAGHeading((real) D2R * gUserConfiguration.rtkHeading2magHeading);
             result = TRUE;
             break;
         // case USER_XXX_OFFSET:  add function calls here if parameter XXXX


### PR DESCRIPTION
<!-- 
[sc-59321] 
-->
Op top of:
- [ ] https://github.com/tidewise/firmwares-imu_aceinna_openimu/pull/9

### What is this PR for

Use moving base RTK measurement as source for heading measurements when:
1. `rtkHeading2magHeading` property is other than `NaN`
1. the moving base rtk measurement is valid

### Review

This is by far the most critical PR in this "RTK series". We must ensure that we can at least disable it by setting `rtkHeading2magHeading` paramter to `NaN`
