### PR TITLE
fix: working version of RTK heading

### DIFF
--- a/lib/Core/GPS/src/driverGPS.c
+++ b/lib/Core/GPS/src/driverGPS.c
@@ -311,8 +311,8 @@ void GetGPSData(gpsDataStruct_t *data)
         data->geoidAboveEllipsoid = gGpsDataPtr->geoidAboveEllipsoid;
 
         data->rtkHeadingData.valid = gGpsData.movingBaseRTKValid;
-        data->rtkHeadingData.heading = gGpsData.relPosHeading * D2R;
-        data->rtkHeadingData.headingAccuracy = gGpsData.accRelPosHeading * D2R;
+        data->rtkHeadingData.heading = gGpsData.relPosHeading;
+        data->rtkHeadingData.headingAccuracy = gGpsData.accRelPosHeading;
     }
 }
 

--- a/lib/Core/GPS/src/processUbloxGPS.c
+++ b/lib/Core/GPS/src/processUbloxGPS.c
@@ -499,15 +499,15 @@ void decodeNavPvt(char *msg, GpsData_t *GPSData)
 }
 
 void extractHeadingFromRelPosNed(char *msg, GpsData_t* GPSData) {
-    int relPosHeading = *( (int *) msg + 24 );
+    int32_t relPosHeading = *(int32_t*)(msg + 24);
     GPSData->relPosHeading = relPosHeading * 1e-5 * D2R;
 
-    unsigned int accRelPosHeading = *( (unsigned int*) msg + 52 );
+    uint32_t accRelPosHeading = *(uint32_t*)(msg + 52);
     GPSData->accRelPosHeading = accRelPosHeading * 1e-5 * D2R;
 
     // Here I don't really know if these are the only flags I should look for.
     // For now it is just a guess of mine
-    unsigned int flags = * ( (unsigned int*) msg + 60);
+    uint32_t flags = *(uint32_t*)(msg + 60);
     bool gnssFixOK = (flags & 0x01) != 0;
     bool rtkFixedSolution = (flags & 0x10) != 0;
     bool relPosHeadingValid = (flags & 0x100) != 0;

--- a/lib/Core/GPS/src/processUbloxGPS.c
+++ b/lib/Core/GPS/src/processUbloxGPS.c
@@ -500,10 +500,10 @@ void decodeNavPvt(char *msg, GpsData_t *GPSData)
 
 void extractHeadingFromRelPosNed(char *msg, GpsData_t* GPSData) {
     int relPosHeading = *( (int *) msg + 24 );
-    GPSData->relPosHeading = relPosHeading * 1e-5;
+    GPSData->relPosHeading = relPosHeading * 1e-5 * D2R;
 
     unsigned int accRelPosHeading = *( (unsigned int*) msg + 52 );
-    GPSData->accRelPosHeading = accRelPosHeading * 1e-5;
+    GPSData->accRelPosHeading = accRelPosHeading * 1e-5 * D2R;
 
     // Here I don't really know if these are the only flags I should look for.
     // For now it is just a guess of mine

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,6 +39,30 @@ build_flags =
 ;	-Wl,-Tstm32f40x.ld
 	-mthumb -mcpu=cortex-m4 -mfloat-abi=softfp -mfpu=fpv4-sp-d16
 
+[env:OpenIMU300ZI-DEBUG]
+platform = aceinna_imu
+build_type = debug
+lib_archive = false
+board = OpenIMU300
+lib_extra_dirs = "./lib/openIMU300-lib"
+build_flags =
+	-D CLI
+	-D GPS
+	-D SPI_BUS_COMM
+	-D __FPU_PRESENT
+	-D DISPLAY_DIAGNOSTIC_MSG
+	-D ARM_MATH_CM4
+	-I include
+	-I include/API
+	-I src/user
+	-I src
+;	-L ldscripts
+	-Og
+;	-Wno-comment
+;	-Wl,-Map,imu380.map
+;	-Wl,-Tstm32f40x.ld
+	-mthumb -mcpu=cortex-m4 -mfloat-abi=softfp -mfpu=fpv4-sp-d16
+
 ;upload_protocol = jlink
 ;debug_tool = jlink
 

--- a/src/user/UserAlgorithm.c
+++ b/src/user/UserAlgorithm.c
@@ -69,6 +69,7 @@ void InitUserAlgorithm()
     setPointOfInterest( (real)gUserConfiguration.pointOfInterestBx,
                         (real)gUserConfiguration.pointOfInterestBy,
                         (real)gUserConfiguration.pointOfInterestBz );
+    setRTKHeading2MAGHeading(gUserConfiguration.rtkHeading2magHeading);
 }
 
 


### PR DESCRIPTION
I could verify that the heading matches the one from the logs, and that the driver would report it. However, the GPS
logs did not match the gyro behaviour on my table, which created nonsensical dynamic behaviour - expected.

I believe there are quite a few issues to solve still, but this could be workable if we increase the accuracy.