### PR TITLE
fix: artificially limit the covariance of the RTK heading to 2 degrees^2

### DIFF
--- a/lib/Core/Algorithm/src/UpdateFunctions.c
+++ b/lib/Core/Algorithm/src/UpdateFunctions.c
@@ -666,8 +666,17 @@ static void _GenerateObservationCovariance_AHRS_Yaw()
      * CHANGED TO SWITCH BETWEEN GPS AND MAG UPDATES
      */
     if (useRTKHeading) {
-        gKalmanFilter.R[STATE_YAW] = gEKFInput.rtkHeading.headingAccuracy *
-            gEKFInput.rtkHeading.headingAccuracy;
+        // Limit the covariance to 2 degrees
+        //
+        // This accounts to the complete lack of synchronization, which on a system
+        // like tupan means something that 2-3 degree of error.
+        if (gEKFInput.rtkHeading.headingAccuracy > 0.035) {
+            gKalmanFilter.R[STATE_YAW] = gEKFInput.rtkHeading.headingAccuracy *
+                gEKFInput.rtkHeading.headingAccuracy;
+        }
+        else {
+            gKalmanFilter.R[STATE_YAW] = 0.0013;
+        }
     }
     else if ( useGpsHeading )
     {

--- a/src/appVersion.h
+++ b/src/appVersion.h
@@ -26,7 +26,7 @@ limitations under the License.
 #ifndef _INS_APP_VERSION_H
 #define _INS_APP_VERSION_H
 
-#define  APP_VERSION_STRING  "OpenIMU300ZI INS 1.1.1 TW2beta3.7"
+#define  APP_VERSION_STRING  "OpenIMU300ZI INS 1.1.1 TW2beta3.8"
 
 
 #endif


### PR DESCRIPTION
This is to account for a lot of errors not related directly to the reading, but for e.g. lack of proper time sync.
