### PR TITLE
chore: rework heading handling

### DIFF
--- a/lib/Core/Algorithm/include/algorithm.h
+++ b/lib/Core/Algorithm/include/algorithm.h
@@ -171,6 +171,13 @@ typedef struct
                                      */
 } STATIC_DETECT_SETTING;
 
+typedef enum
+{
+    HEADING_SOURCE_NONE,
+    HEADING_SOURCE_MAG_MAGNETIC,
+    HEADING_SOURCE_MAG_GEOGRAPHIC,
+    HEADING_SOURCE_RTK
+} HeadingSource;
 
 /* Global Algorithm structure  */
 typedef struct {
@@ -182,8 +189,9 @@ typedef struct {
     uint8_t     state;			// takes values from HARDWARE_STABILIZE to INIT_ATTITUDE to HG_AHRS
 
     uint8_t insFirstTime;
-    uint8_t headingIni;
-    uint8_t applyDeclFlag;
+    HeadingSource headingSource;
+    float heading;
+    float headingCovariance;
 
     int32_t timeOfLastSufficientGPSVelocity;
     int32_t timeOfLastGoodGPSReading;

--- a/lib/Core/Algorithm/src/PredictFunctions.c
+++ b/lib/Core/Algorithm/src/PredictFunctions.c
@@ -179,14 +179,6 @@ void EKF_PredictionStage(real *filteredAccel)
         //   forces the error to zero)
         gKalmanFilter.measuredEulerAngles[YAW] = gKalmanFilter.eulerAngles[YAW];
     }
-
-
-    // Adjust for declination if we have declination data
-    if( gWorldMagModel.validSoln )
-    {
-        gKalmanFilter.measuredEulerAngles[YAW] = gKalmanFilter.measuredEulerAngles[YAW] +
-                                                 gWorldMagModel.decl_rad;
-    }
 }
 
 

--- a/lib/Core/Algorithm/src/SelectState.c
+++ b/lib/Core/Algorithm/src/SelectState.c
@@ -335,22 +335,6 @@ void INS_To_AHRS_Transition_Test(void)
     {
         gAlgorithm.timeOfLastSufficientGPSVelocity = (int32_t)gEKFInput.itow;
     }
-    /* Determine the length of time it has been since the system 'moved' --
-     * only linear motion considered (rotations ignored).
-     */
-    int32_t timeSinceRestBegan = (int32_t)gEKFInput.itow - gAlgorithm.timeOfLastSufficientGPSVelocity;
-    if (timeSinceRestBegan < 0)
-    {
-        timeSinceRestBegan = timeSinceRestBegan + MAX_ITOW;
-    }
-    if (timeSinceRestBegan > LIMIT_MAX_REST_TIME_BEFORE_HEADING_INVALID && gAlgorithm.headingIni != HEADING_UNINITIALIZED)
-    {
-        gAlgorithm.headingIni = HEADING_GNSS_LOW;
-#ifdef DISPLAY_DIAGNOSTIC_MSG
-        DebugPrintString("Rest for too long.");
-        DebugPrintEndline();
-#endif
-    }
 
     // compute time since the last good GPS reading
     int32_t timeSinceLastGoodGPSReading = (int32_t)gAlgorithm.itow - gAlgorithm.timeOfLastGoodGPSReading;
@@ -366,7 +350,6 @@ void INS_To_AHRS_Transition_Test(void)
 
         // Currently in INS mode but requiring a transition to AHRS / VG
         gAlgorithm.insFirstTime = TRUE;
-        gAlgorithm.headingIni = HEADING_UNINITIALIZED;
 
         /* The transition from INS to AHRS and back to INS does not seem to
          * generate a stable solution if we transition to LG AHRS for only 30
@@ -379,14 +362,6 @@ void INS_To_AHRS_Transition_Test(void)
 
         // Set linear-acceleration switch variables
         gAlgorithm.linAccelSwitchCntr = 0;
-
-#ifdef DISPLAY_DIAGNOSTIC_MSG
-        if (magUsedInAlgorithm()) {
-            TimingVars_DiagnosticMsg("Transitioning to low-gain AHRS mode");
-        } else {
-            TimingVars_DiagnosticMsg("Transitioning to low-gain VG mode");
-        }
-#endif
 
         gAlgoStatus.bit.highGain              = ( gAlgorithm.state == HIGH_GAIN_AHRS );
         gAlgoStatus.bit.attitudeOnlyAlgorithm = TRUE;

--- a/lib/Core/Algorithm/src/UpdateFunctions.c
+++ b/lib/Core/Algorithm/src/UpdateFunctions.c
@@ -28,7 +28,7 @@
 #include "EKF_Algorithm.h"
 #include "UpdateFunctions.h"
 #include "SensorNoiseParameters.h"
-
+#include "WorldMagneticModel.h"
 
 extern ImuStatsStruct gImuStats;
 
@@ -63,26 +63,16 @@ static real _LimitValue( real value, real limit );
 static BOOL _CheckForUpdateTrigger(uint8_t updateRate);
 
 static void ApplyGpsDealyCorrForStateCov();
+static void ComputeSystemInnovation_Att_Yaw();
+
+static void Update_GPS(void);
+static void Update_PseudoMeasurement(void);
+static void GenPseudoMeasCov(real *r);
+static void Update_Heading();
+static void Update_AHRS();
 
 /******************************************************************************
- * @brief Initializa heading using GNSS heading.
- * If the GNSS heading is valid and the vehicle is drving forward, the GNSS
- * heading is considered valid, and the eading will be initialized to be
- * gEKFInput.trueCourse, and velocity will also be initiazlied as the
- * corresponding NED speed. After this, the quaternion (q0 and q3) and velocity
- * terms in the state covariance matrix P will be reset. Non-diagonal terms will be
- * set as 0s, and diagonal terms will be set according to estimated variance. The
- * cov(quaternion, velocity) should also be updated. But the positive-definiteness
- * is not guaranteed this way.
- * TRACE:
- * @retval TRUE if heading initialized/reinitialized, FALSE if not.
-******************************************************************************/
-static int InitializeHeadingFromGnss();
-
-static int InitializeHeadingFromRTK();
-
-/******************************************************************************
- * @brief When heading is ready for initialization, the heading angle (yaw, and 
+ * @brief When heading is ready for initialization, the heading angle (yaw, and
  * indeed quaternion in the Kalman filter) is initialized to match the value of
  * gEKFInput.trueCourse, and velocity will also be initiazlied as the
  * corresponding NED speed. After this, the quaternion (q0 and q3) and velocity
@@ -93,9 +83,7 @@ static int InitializeHeadingFromRTK();
  * TRACE:
  * @retval None.
 ******************************************************************************/
-static void InitializeEkfHeading(float headingMeasurement, float headingMeasurementCov);
-
-static void computeHeadingFromGps(float* heading, float* covariance);
+static bool initializeEkfHeading(float headingMeasurement, float headingMeasurementCov);
 
 // Update rates
 #define  TEN_HERTZ_UPDATE          10
@@ -123,10 +111,6 @@ static int runInsUpdate = 0;    /* To enable the update to be broken up into
 // Uncomment to run only AHRS-type updates
 //#define ATT_UPDATE_ONLY
 
-static void Update_GPS(void);
-static void Update_PseudoMeasurement(void);
-static void GenPseudoMeasCov(real *r);
-
 // EKF_UpdateStage.m
 void EKF_UpdateStage(void)
 {
@@ -147,11 +131,7 @@ void EKF_UpdateStage(void)
             // Subframe counter counts to 10 before it is reset
             if( _CheckForUpdateTrigger(TEN_HERTZ_UPDATE) )
             {
-                /* The AHRS/VG solution is handled inside FieldVectorsToEulerAngles
-                 * (called from the prediction function EKF_PredictionStage)
-                 */
-                ComputeSystemInnovation_Att();
-                Update_Att();
+                Update_AHRS();
             }
         }
     } 
@@ -234,7 +214,7 @@ void EKF_UpdateStage(void)
             }
             
             // apply motion constraints
-            if (gAlgorithm.velocityAlwaysAlongBodyX && gAlgorithm.headingIni>HEADING_UNINITIALIZED)
+            if (gAlgorithm.velocityAlwaysAlongBodyX && gAlgorithm.headingSource != HEADING_SOURCE_NONE)
             {
                 Update_PseudoMeasurement();
             }
@@ -256,6 +236,16 @@ void EKF_UpdateStage(void)
     }
 
     gAlgoStatus.bit.usingRTKHeading = useRTKHeading;
+}
+
+static void Update_AHRS() {
+    /* The AHRS/VG solution is handled inside FieldVectorsToEulerAngles
+     * (called from the prediction function EKF_PredictionStage)
+     */
+    Update_Heading();
+    ComputeSystemInnovation_Att_Yaw();
+    ComputeSystemInnovation_Att();
+    Update_Att();
 }
 
 // ----Compute the innovation vector, nu----
@@ -303,44 +293,58 @@ void ComputeSystemInnovation_Vel(void)
     gKalmanFilter.nu[STATE_VZ] = _LimitValue(gKalmanFilter.nu[STATE_VZ], gAlgorithm.Limit.Innov.velocityError);
 }
 
-static void ComputeSystemInnovation_Att_Yaw(void)
+static float computeRTKHeadingCovariance();
+static float computeMagHeadingCovariance();
+
+static void computeHeading(HeadingSource* source, float* heading, float* headingCov)
 {
     // ----- Yaw -----
     // CHANGED TO SWITCH BETWEEN GPS AND MAG UPDATES
     if (useRTKHeading) {
-        gKalmanFilter.nu[STATE_YAW] = gEKFInput.rtkHeading.heading -
-            gKalmanFilter.eulerAngles[YAW];
+        *heading = gEKFInput.rtkHeading.heading;
+        *headingCov = computeRTKHeadingCovariance();
+        *source = HEADING_SOURCE_RTK;
     }
-    else if ( useGpsHeading )
+    else if (magUsedInAlgorithm())
     {
-        if (gAlgorithm.headingIni >= HEADING_GNSS_LOW)   // heading already initialized with GNSS heading
+        // Adjust for declination if we have declination data
+        float declination = 0;
+        if( gWorldMagModel.validSoln )
         {
-            if (gAlgoStatus.bit.ppsAvailable)
-            {
-                gKalmanFilter.nu[STATE_YAW] = gEKFInput.trueCourse * (real)DEG_TO_RAD -
-                                              gKalmanFilter.ppsEulerAngles[YAW];
-            }
-            else
-            {
-                gKalmanFilter.nu[STATE_YAW] = gEKFInput.trueCourse * (real)DEG_TO_RAD -
-                                              gKalmanFilter.eulerAngles[YAW];
-            }
+            declination = gWorldMagModel.decl_rad;
+            *source = HEADING_SOURCE_MAG_GEOGRAPHIC;
         }
-        else
-        {
-            gKalmanFilter.nu[STATE_YAW] = 0.0;
+        else {
+            *source = HEADING_SOURCE_MAG_MAGNETIC;
         }
-        
+
+        *heading = gKalmanFilter.measuredEulerAngles[YAW] + declination;
+        *headingCov = computeMagHeadingCovariance();
     }
-    else if ( magUsedInAlgorithm() && (!gAlgorithm.velocityAlwaysAlongBodyX || gAlgorithm.state <= LOW_GAIN_AHRS) )
+    else
     {
-        gKalmanFilter.nu[STATE_YAW]   = gKalmanFilter.measuredEulerAngles[YAW] -
-                                        gKalmanFilter.eulerAngles[YAW];
+        *heading = 0;
+        *headingCov = 1.0;
+        *source = HEADING_SOURCE_NONE;
     }
-    else 
+}
+
+static void ComputeSystemInnovation_Att_Yaw()
+{
+    if (gAlgorithm.headingSource == HEADING_SOURCE_NONE) {
+        gKalmanFilter.nu[STATE_YAW] = 0;
+        return;
+    }
+
+    if (gAlgoStatus.bit.ppsAvailable)
     {
-        gKalmanFilter.nu[STATE_YAW] = (real)0.0;
+        gKalmanFilter.nu[STATE_YAW] = gAlgorithm.heading - gKalmanFilter.ppsEulerAngles[YAW];
     }
+    else
+    {
+        gKalmanFilter.nu[STATE_YAW] = gAlgorithm.heading - gKalmanFilter.eulerAngles[YAW];
+    }
+
     gKalmanFilter.nu[STATE_YAW] = _UnwrapAttitudeError(gKalmanFilter.nu[STATE_YAW]);
     gKalmanFilter.nu[STATE_YAW] = _LimitValue(gKalmanFilter.nu[STATE_YAW], gAlgorithm.Limit.Innov.attitudeError);
 }
@@ -361,14 +365,6 @@ void ComputeSystemInnovation_Att(void)
                                     gKalmanFilter.eulerAngles[PITCH];
     gKalmanFilter.nu[STATE_PITCH] = _UnwrapAttitudeError(gKalmanFilter.nu[STATE_PITCH]);
     gKalmanFilter.nu[STATE_PITCH] = _LimitValue(gKalmanFilter.nu[STATE_PITCH], gAlgorithm.Limit.Innov.attitudeError);
-
-    if (updateHeading) {
-        ComputeSystemInnovation_Att_Yaw();
-    }
-    else {
-        gKalmanFilter.nu[STATE_YAW] = (real) 0.0;
-
-    }
 
     /* When the filtered yaw-rate is above certain thresholds then reduce the
      * attitude-errors used to update roll and pitch.
@@ -623,11 +619,42 @@ void _GenerateObservationCovariance_AHRS(void)
         gKalmanFilter.R[STATE_PITCH] = maxR;
     }
 
-    if (updateHeading) {
-        _GenerateObservationCovariance_AHRS_Yaw();
+    gKalmanFilter.R[STATE_YAW] = gAlgorithm.headingCovariance;
+}
+
+static float computeRTKHeadingCovariance()
+{
+    // Limit the covariance to 2 degrees
+    //
+    // This accounts to the complete lack of synchronization, which on a system
+    // like tupan means something that 2-3 degree of error.
+    if (gEKFInput.rtkHeading.headingAccuracy > 0.035) {
+        return gEKFInput.rtkHeading.headingAccuracy *
+            gEKFInput.rtkHeading.headingAccuracy;
     }
     else {
-        gKalmanFilter.R[STATE_YAW] = (real)1.0;
+        return 0.0013;
+    }
+}
+
+static float computeMagHeadingCovariance() {
+    /* For 'large' roll/pitch angles, increase R-yaw to decrease the effect
+     * of update due to potential uncompensated z-axis magnetometer
+     * readings from affecting the yaw-update.
+     */
+    if( ( gKalmanFilter.eulerAngles[ROLL]  > TEN_DEGREES_IN_RAD ) ||
+        ( gKalmanFilter.eulerAngles[PITCH] > TEN_DEGREES_IN_RAD ) )
+    {
+        return (real)0.2;
+    }
+
+    if ((gAlgorithm.state == HIGH_GAIN_AHRS) || gAlgorithm.linAccelSwitch)
+    {
+        // --- High-Gain ---
+        return (real)1.0e-2;  // jun4
+    } else {
+        // --- Low-Gain ---
+        return (real)1.0e-1; // v14.6 values
     }
 }
 
@@ -752,12 +779,13 @@ void _GenerateObservationCovariance_INS(void)
     {
         temp *= (1.0f + absFilteredYawRate);
     }
+    temp *= temp;
     gKalmanFilter.R[STATE_VX] = temp;// *((real)1.0 + fabs(gAlgorithm.filteredYawRate) * (real)RAD_TO_DEG);
-    gKalmanFilter.R[STATE_VX] = gKalmanFilter.R[STATE_VX] * gKalmanFilter.R[STATE_VX];
-    gKalmanFilter.R[STATE_VY] = gKalmanFilter.R[STATE_VX];
-    if (!magUsedInAlgorithm() && gAlgorithm.headingIni == HEADING_UNINITIALIZED)
+    gKalmanFilter.R[STATE_VY] = temp;
+
+    if (gAlgorithm.headingSource == HEADING_SOURCE_NONE)
     {
-        /* When heading is not initialized, velocity measurement is not able to correct 
+        /* When heading is not initialized, velocity measurement is not able to correct
          * attitude/rate bias/accel bias, the larger the velocity, the more uncertain it is.
          */
         gKalmanFilter.R[STATE_VX] += SQUARE(gEKFInput.vNed[0]) + SQUARE(gEKFInput.vNed[1]);
@@ -1282,23 +1310,38 @@ static void Update_GPS(void)
     Update_Pos();
     ComputeSystemInnovation_Vel();
     Update_Vel();
+
+    Update_Heading();
+    if (updateHeading) {
+        ComputeSystemInnovation_Att_Yaw();
+    }
+    else {
+        gKalmanFilter.nu[STATE_YAW] = (real) 0.0;
+    }
+
     ComputeSystemInnovation_Att();
+}
 
-    if (gAlgorithm.velocityAlwaysAlongBodyX && gAlgorithm.headingIni < HEADING_GNSS_HIGH)
-    {
-        if (InitializeHeadingFromGnss())
-        {
-            float heading, cov;
-            computeHeadingFromGps(&heading, &cov);
-            // Heading is initialized. Related elements in the EKF also need intializing.
-            InitializeEkfHeading(heading, cov);
+static void Update_Heading() {
+    HeadingSource source;
+    float heading;
+    float headingCov;
+    computeHeading(&source, &heading, &headingCov);
 
-            /* This heading measurement is used to initialize heading, and should not be
-             * used to update heading.
-             */
-            useGpsHeading = FALSE;
+    if (gAlgorithm.headingSource != source) {
+        if (initializeEkfHeading(heading, headingCov)) {
+            updateHeading = false;
+            gAlgorithm.headingSource = source;
         }
     }
+
+    if (source == HEADING_SOURCE_NONE) {
+        updateHeading = false;
+    }
+
+    // Pass the covariance to the second stage of the update
+    gAlgorithm.heading = heading;
+    gAlgorithm.headingCovariance = headingCov;
 }
 
 static void Update_PseudoMeasurement(void)
@@ -1744,167 +1787,7 @@ static BOOL _CheckForUpdateTrigger(uint8_t updateRate)
     return updateFlag;
 }
 
-static int InitializeHeadingFromGnss()
-{
-    /* enable declination correction, but the corrected magnetic yaw will not
-     * be used if GPS is available.
-     */
-    gAlgorithm.applyDeclFlag = TRUE;
-
-    /* backward drive detection for heading initialization using GNSS heading.
-     * Detection happends every second. Velocity increment is relatively reliable
-     * if it is accumulated for 1sec.
-     */
-    static real lastVelBxGnss = 0;
-    static uint8_t forwardDriveConfidence = 0;
-    static uint32_t lastTOW = 0;
-    uint32_t timeSinceLastDetection = gAlgorithm.itow - lastTOW;
-    if (timeSinceLastDetection < 0)
-    {
-        timeSinceLastDetection = timeSinceLastDetection + MAX_ITOW;
-    }
-    if (timeSinceLastDetection > 950)   // 950ms is set as the threshold for 1sec
-    {
-        lastTOW = gAlgorithm.itow;
-        /* assume velocity is always along the body x axis. otherwise, GNSS heading
-         * cannot be used to initialize fusion heading
-         */
-        real velBx = sqrtf(SQUARE(gEKFInput.vNed[0]) + SQUARE(gEKFInput.vNed[1]) + SQUARE(gEKFInput.vNed[2]));
-        velBx = fabs(velBx);
-        real dv = velBx - lastVelBxGnss;
-        if ((dv * gKalmanFilter.linearAccel_B[X_AXIS]) > 0.0 && fabs(gKalmanFilter.linearAccel_B[X_AXIS]) > 0.2)
-        {
-            if (forwardDriveConfidence < 255)
-            {
-                forwardDriveConfidence++;
-            }
-        }
-        else
-        {
-            forwardDriveConfidence = 0;
-        }
-        // record this velocity along body x axis for next run
-        lastVelBxGnss = velBx;
-        // reset accumulated x body axis velocity change.
-        gKalmanFilter.linearAccel_B[X_AXIS] = 0.0;
-    }
-
-    // detect if GNSS heading is reliable
-    static uint8_t gnssHeadingGoodCntr = 0;
-    static float lastGnssHeading = 0.0;
-    static float lastFusionHeading = 0.0;
-    BOOL gnssHeadingGood = 0;
-    float angleDiff = 0.0;
-    if (useGpsHeading)
-    {
-        float calculatedGnssHeading  = (float)(atan2(gEKFInput.vNed[1], gEKFInput.vNed[0]) * R2D);
-        float diffHeading = AngleErrDeg(gEKFInput.trueCourse - calculatedGnssHeading);
-        // input GNSS heading matches heading calculated from vNED
-        if (fabs(diffHeading) < 5.0)
-        {
-            // GNSS heading change matches fusion yaw angle
-            float gnssHeadingChange = gEKFInput.trueCourse - lastGnssHeading;
-            float fusionHeadingChange = gKalmanFilter.eulerAngles[2] * (float)R2D - lastFusionHeading;
-            angleDiff = (float)fabs( AngleErrDeg(gnssHeadingChange - fusionHeadingChange) );
-            if (angleDiff < 5.0)
-            {
-                gnssHeadingGood = TRUE;
-            }
-        }
-        lastGnssHeading = gEKFInput.trueCourse;
-        lastFusionHeading = gKalmanFilter.eulerAngles[2] * (float)R2D;
-    }
-    if (gnssHeadingGood)
-    {
-        gnssHeadingGoodCntr++;
-    }
-    else
-    {    
-        gnssHeadingGoodCntr = 0;
-    }
-    
-    // Heading initialization when drive forward and GNSS heading is reliable
-    BOOL thisHeadingUsedForIni = FALSE;
-    if (gAlgorithm.headingIni < HEADING_GNSS_LOW)   // heading is immediately but maybe unreliably initialized
-    {
-        if (gnssHeadingGoodCntr >= 1 && forwardDriveConfidence >= 1)   // Only one sample is checked, so heading may be unreliable
-        {
-            gnssHeadingGoodCntr = 0;
-            // Heading is initialized with GNSS
-            gAlgorithm.headingIni = HEADING_GNSS_LOW;
-
-#ifdef INS_OFFLINE
-            printf("quick gps heading: %f\n", gEKFInput.trueCourse);
-#else
-#ifdef DISPLAY_DIAGNOSTIC_MSG
-            DebugPrintString("quick gps heading");
-            DebugPrintFloat(": ", gEKFInput.trueCourse, 9);
-            DebugPrintEndline();
-#endif
-#endif
-            thisHeadingUsedForIni = TRUE;
-        }
-    }
-    else
-    {
-        /* Three points are checked, and the latest ground speed is above a certian threshold.
-         * The latest GNSS heading should be reliable.
-         */
-        if (gnssHeadingGoodCntr >= 3 && 
-            forwardDriveConfidence >= 5 && 
-            gEKFInput.rawGroundSpeed > RELIABLE_GPS_VELOCITY_HEADING)
-        {
-            gnssHeadingGoodCntr = 0;
-            forwardDriveConfidence = 0;
-            gAlgorithm.headingIni = HEADING_GNSS_HIGH;
-#ifdef INS_OFFLINE
-            printf("reliable gps heading: %f\n", gEKFInput.trueCourse);
-#else
-#ifdef DISPLAY_DIAGNOSTIC_MSG
-            DebugPrintString("reliable gps heading");
-            DebugPrintFloat(": ", gEKFInput.trueCourse, 9);
-            DebugPrintEndline();
-#endif
-#endif
-            thisHeadingUsedForIni = TRUE;
-        }
-    }
-
-    return thisHeadingUsedForIni;
-}
-
-static int InitializeHeadingFromRTK()
-{
-    /* enable declination correction, but the corrected magnetic yaw will not
-     * be used if GPS is available.
-     */
-    gAlgorithm.applyDeclFlag = TRUE;
-
-    if (useRTKHeading) {
-        gAlgorithm.headingIni = HEADING_RTK;
-        return true;
-    }
-
-    return false;
-}
-
-static void computeHeadingFromGps(float* heading, float* covariance)
-{
-    *heading = gEKFInput.trueCourse * D2R;
-
-    // the initial covariance of the quaternion is estimated from ground speed.
-    float temp = (float)atan(0.05 / gEKFInput.rawGroundSpeed);
-    temp *= temp;   // heading var
-    if (gAlgoStatus.bit.turnSwitch)
-    {
-        temp *= 10.0;   // when rotating, heading var increases
-    }
-    temp /= 4.0;        // sin(heading/2) or cos(heading/2)
-
-    *covariance = temp;
-}
-
-static void InitializeEkfHeading(float headingMeasurement, float headingMeasurementCov)
+static bool initializeEkfHeading(float headingMeasurement, float headingMeasurementCov)
 {
     /* Compare the reliable heading with Kalamn filter heading. If the difference exceeds
      * a certain threshold, this means the immediate heading initialization is unreliable,
@@ -1914,18 +1797,8 @@ static void InitializeEkfHeading(float headingMeasurement, float headingMeasurem
                                               gKalmanFilter.eulerAngles[2])));
     if (angleDiff <= 2.0)
     {
-        return;
+        return false;
     }
-
-#ifdef INS_OFFLINE
-        printf("Reinitialize KF: %f\n", angleDiff);
-#else
-#ifdef DISPLAY_DIAGNOSTIC_MSG
-        DebugPrintString("Reinitialize KF: ");
-        DebugPrintFloat("", angleDiff, 9);
-        DebugPrintEndline();
-#endif
-#endif
 
     // initialize yaw angle with GPS heading
     gKalmanFilter.eulerAngles[YAW] = headingMeasurement;
@@ -1945,7 +1818,6 @@ static void InitializeEkfHeading(float headingMeasurement, float headingMeasurem
     gKalmanFilter.Velocity_N[Y_AXIS] = (real)gEKFInput.vNed[Y_AXIS];
     gKalmanFilter.Velocity_N[Z_AXIS] = (real)gEKFInput.vNed[Z_AXIS];
 
-#if 1   // mod, DXG
     // reset quaternion and velocity terms in the P matrix
     int i, j;
     // pos row
@@ -2007,38 +1879,7 @@ static void InitializeEkfHeading(float headingMeasurement, float headingMeasurem
     gKalmanFilter.P[STATE_VY][STATE_VY] = gKalmanFilter.R[STATE_VY];
     gKalmanFilter.P[STATE_VZ][STATE_VZ] = gKalmanFilter.R[STATE_VZ];
 
-#if 0
-    // reset velocity and quaternion terms in the P matrix
-    real v2 = gEKFInput.rawGroundSpeed * gEKFInput.rawGroundSpeed;
-    real v3by4 = 4.0 * v2 * gEKFInput.rawGroundSpeed;
-    real vn2 = gEKFInput.vNed[0] * gEKFInput.vNed[0];
-    real q0q0 = gKalmanFilter.quaternion[0] * gKalmanFilter.quaternion[0];
-    real q3q3 = gKalmanFilter.quaternion[3] * gKalmanFilter.quaternion[3];
-    if (q0q0 < 1.0e-3)
-    {
-        q0q0 = 1.0e-3;
-    }
-    if (q3q3 < 1.0e-3)
-    {
-        q3q3 = 1.0e-3;
-    }
-    real multiplerQVn = (v2 - vn2) / v3by4;
-    multiplerQVn *= multiplerQVn;
-    real multiplerQVe = (gEKFInput.vNed[0] * gEKFInput.vNed[1]) / v3by4;
-    multiplerQVe *= multiplerQVe;
-    gKalmanFilter.P[STATE_VX][STATE_Q0] = multiplerQVn / q0q0 * gKalmanFilter.R[STATE_VX][STATE_VX];
-    gKalmanFilter.P[STATE_VX][STATE_Q3] = multiplerQVn / q3q3 * gKalmanFilter.R[STATE_VX][STATE_VX];
-    gKalmanFilter.P[STATE_VY][STATE_Q0] = multiplerQVe / q0q0 * gKalmanFilter.R[STATE_VY][STATE_VY];
-    gKalmanFilter.P[STATE_VY][STATE_Q3] = multiplerQVe / q3q3 * gKalmanFilter.R[STATE_VY][STATE_VY];
-
-
-    gKalmanFilter.P[STATE_Q0][STATE_VX] = gKalmanFilter.P[STATE_VX][STATE_Q0];
-    gKalmanFilter.P[STATE_Q3][STATE_VX] = gKalmanFilter.P[STATE_VX][STATE_Q3];
-    gKalmanFilter.P[STATE_Q0][STATE_VY] = gKalmanFilter.P[STATE_VY][STATE_Q0];
-    gKalmanFilter.P[STATE_Q3][STATE_VY] = gKalmanFilter.P[STATE_VY][STATE_Q3];
-#endif
-
-#endif
+    return true;
 }
 
 static void ApplyGpsDealyCorrForStateCov()

--- a/lib/Core/Algorithm/src/algorithm.c
+++ b/lib/Core/Algorithm/src/algorithm.c
@@ -73,14 +73,7 @@ void InitializeAlgorithmStruct(uint8_t callingFreq)
     // Turn-switch variable
     gAlgorithm.filteredYawRate = (real)0.0;
 
-    // Tell the algorithm to apply the declination correction to the heading
-    //  (at startup in AHRS, do not apply.  After INS becomes healthy, apply,
-    //  even in AHRS, but this condition shouldn't last forever.  Question:
-    //  how long to keep this set TRUE after GPS in invalid?)
-    gAlgorithm.applyDeclFlag = FALSE;
-
     gAlgorithm.insFirstTime = TRUE;
-    gAlgorithm.headingIni = HEADING_UNINITIALIZED;
 
     gAlgorithm.timeOfLastGoodGPSReading = -MAX_ITOW;
     gAlgorithm.timeOfLastGoodRTKHeading = -MAX_ITOW;
@@ -107,7 +100,7 @@ void InitializeAlgorithmStruct(uint8_t callingFreq)
     gAlgorithm.Limit.Innov.positionError = (real)270.0;
     gAlgorithm.Limit.Innov.velocityError = (real)27.0;
     gAlgorithm.Limit.Innov.attitudeError = (real)SIX_DEGREES_IN_RAD;
-    
+
     // Five-hertz LPF (corresponding integer value found in PredictFunctions.c)
     // Replace with a function that computes the coefficients.  Value (below) will
     //   then be the cutoff frequency.
@@ -117,6 +110,10 @@ void InitializeAlgorithmStruct(uint8_t callingFreq)
     //  and smooth linear acceleration. But on some platform, there is large vibration,
     //  uing raw accel to detect linear acceleration will always detect linear accel.
     gAlgorithm.useRawAccToDetectLinAccel = TRUE;
+
+    gAlgorithm.headingSource = HEADING_SOURCE_NONE;
+    gAlgorithm.heading = 0;
+    gAlgorithm.headingCovariance = 1.0;
 
     // Set the turn-switch threshold to a default value in [deg/sec]
     gAlgorithm.turnSwitchThreshold = 6.0;

--- a/src/appVersion.h
+++ b/src/appVersion.h
@@ -26,7 +26,6 @@ limitations under the License.
 #ifndef _INS_APP_VERSION_H
 #define _INS_APP_VERSION_H
 
-#define  APP_VERSION_STRING  "OpenIMU300ZI INS 1.1.1 TW2beta3.8"
-
+#define  APP_VERSION_STRING  "OpenIMU300ZI INS 1.1.1 TW2beta3.9"
 
 #endif


### PR DESCRIPTION
This partially removes code necessary to use GPS velocity as heading source. It cleans up our case, that is the one where we want to seamlessly switch between RTK heading, mag heading and mag heading with declination.

The main issue with the GNSS heading is that it is not available *at all* at zero velocities, and that it needs time to switch (some validation / integration times). This makes it a lot harder to implement, and since we don't need it, I removed (most of) it.

The heading source is now chosen within the update step. The correction of mag yaw measurement by declination is done there as well to detect the transition from mag and mag-with-decl
