### PR TITLE
chore: decouple gps udpate from rtk availability

### DIFF
--- a/lib/Core/Algorithm/src/EKF_Algorithm.c
+++ b/lib/Core/Algorithm/src/EKF_Algorithm.c
@@ -655,8 +655,8 @@ void EKF_SetInputStruct(double *accels, double *rates, double *mags,
                           &gKalmanFilter.rGPS_N[0]);
         }
 
-        gEKFInput.rtkHeading.valid = gps->rtkHeadingData.valid;
-        if (gEKFInput.rtkHeading.valid) {
+        gEKFInput.rtkHeading.new_data = gps->rtkHeadingData.new_data;
+        if (gEKFInput.rtkHeading.new_data) {
             gEKFInput.rtkHeading.heading = gps->rtkHeadingData.heading
                 + gAlgorithm.rtkHeading2magHeading;
             gEKFInput.rtkHeading.headingAccuracy = gps->rtkHeadingData.headingAccuracy;

--- a/lib/Core/Algorithm/src/UpdateFunctions.c
+++ b/lib/Core/Algorithm/src/UpdateFunctions.c
@@ -267,7 +267,7 @@ static bool computeHeading(HeadingSource* source, float* heading, float* heading
         *source = HEADING_SOURCE_RTK;
         gAlgoStatus.bit.usingRTKHeading = true;
 
-        if (gEKFInput.rtkHeading.valid) {
+        if (gEKFInput.rtkHeading.new_data) {
             gAlgorithm.timeOfLastGoodRTKHeading = gEKFInput.itow;
             *heading = gEKFInput.rtkHeading.heading;
             *headingCov = computeRTKHeadingCovariance();

--- a/lib/Core/GPS/gpsAPI.h
+++ b/lib/Core/GPS/gpsAPI.h
@@ -55,7 +55,9 @@ void TaskGps(void const *argument);
 #define SIMULATION  8   // Simulation Mode (will be considered as INVALID)
 
 typedef struct {
-    uint8_t valid;
+    // new and valid data is available
+    uint8_t new_data;
+
     uint32_t itow;
     float   heading;
     float   headingAccuracy;
@@ -99,7 +101,7 @@ extern gpsDataStruct_t gGPS, gCanGps;
  * @param [in] data - pointer to external GPS structure
  * @retval N/A
  ******************************************************************************/
-void  GetGPSData(gpsDataStruct_t *data, bool wantRelPosHeading);
+void  GetGPSData(gpsDataStruct_t *data);
 BOOL  SetGpsBaudRate(int rate, int fApply);
 BOOL  SetGpsProtocol(int protocol, int fApply);
 

--- a/lib/Core/GPS/src/driverGPS.c
+++ b/lib/Core/GPS/src/driverGPS.c
@@ -271,15 +271,13 @@ int writeGps(char  *data, uint16_t len)
 
 }
 
-void GetGPSData(gpsDataStruct_t *data, bool wantRelPosHeading)
+void GetGPSData(gpsDataStruct_t *data)
 {
     bool hasPosAndVelocityUpdate =
         (gGpsDataPtr->updateFlagForEachCall >> GOT_VTG_MSG) & 0x00000001 &&
         (gGpsDataPtr->updateFlagForEachCall >> GOT_GGA_MSG) & 0x00000001;
 
-    bool relPosHeadingUptodate = (gGpsDataPtr->itow == gGpsDataPtr->relPosHeadingITOW);
-    data->gpsUpdate =
-        hasPosAndVelocityUpdate && (!wantRelPosHeading || relPosHeadingUptodate);
+    data->gpsUpdate = hasPosAndVelocityUpdate;
 
     // gGpsDataPtr->updateFlagForEachCall &= 0xFFFFFFFD;
     if(data->gpsUpdate)
@@ -316,10 +314,16 @@ void GetGPSData(gpsDataStruct_t *data, bool wantRelPosHeading)
         data->GPSVertAcc        = gGpsDataPtr->GPSVertAcc;
         data->geoidAboveEllipsoid = gGpsDataPtr->geoidAboveEllipsoid;
 
-        data->rtkHeadingData.valid = gGpsData.relPosHeadingValid;
-        data->rtkHeadingData.itow = gGpsData.relPosHeadingITOW;
-        data->rtkHeadingData.heading = gGpsData.relPosHeading;
-        data->rtkHeadingData.headingAccuracy = gGpsData.relPosHeadingAccuracy;
+        bool relPosHeadingUptodate =
+            (gGpsDataPtr->itow == gGpsDataPtr->relPosHeadingITOW);
+        data->rtkHeadingData.new_data =
+            gGpsData.relPosHeadingValid && relPosHeadingUptodate;
+        if(data->rtkHeadingData.new_data)
+        {
+            data->rtkHeadingData.itow = gGpsData.relPosHeadingITOW;
+            data->rtkHeadingData.heading = gGpsData.relPosHeading;
+            data->rtkHeadingData.headingAccuracy = gGpsData.relPosHeadingAccuracy;
+        }
     }
 }
 

--- a/src/user/dataProcessingAndPresentation.c
+++ b/src/user/dataProcessingAndPresentation.c
@@ -144,7 +144,7 @@ void inertialAndPositionDataProcessing(uint16_t dacqRate)
         GetBoardTempData(&gIMU.temp_C);
 
         // Obtain GPS data (lat/lon: deg, alt: meters, vel: m/s, ITOW: msec, )
-        GetGPSData(&gGPS, rtkHeadingEnabled());
+        GetGPSData(&gGPS);
 
         // check if pps is detected right before this excution of the task.
         BOOL ppsDetected = platformGetPpsFlag(TRUE);


### PR DESCRIPTION
this dependency would make the overall system be heavilly dependent on RTK. Leading to a complete pose estimation failure when the other GPS goes unavailable for whatever reason.

Even if the other gps goes unavailable  we can still get a reasonable heading with the compass.


